### PR TITLE
Update to v2 of the Trove API

### DIFF
--- a/Your-first-API-request.ipynb
+++ b/Your-first-API-request.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "# Create a variable called 'api_search_url' and give it a value\n",
-    "api_search_url = 'https://api.trove.nla.gov.au/result'"
+    "api_search_url = 'https://api.trove.nla.gov.au/v2/result'"
    ]
   },
   {


### PR DESCRIPTION
Assigned this as an activity in a workshop and realised that the Trove API URL had changed.